### PR TITLE
Data parallel

### DIFF
--- a/argus/model/build.py
+++ b/argus/model/build.py
@@ -211,6 +211,8 @@ class BuildModel(metaclass=ModelMeta):
                 if dev.index is None:
                     raise ValueError
                 device_ids.append(dev.index)
+            if len(device_ids) != len(set(device_ids)):
+                raise ValueError("Cuda device indices must be unique")
             nn_module = DataParallel(nn_module, device_ids=device_ids)
             device = device[0]
 

--- a/argus/model/build.py
+++ b/argus/model/build.py
@@ -8,7 +8,7 @@ from torch import nn
 from torch import optim
 from torch.nn.parallel.data_parallel import DataParallel
 
-from argus.utils import default
+from argus.utils import default, device_to_str
 from argus.loss import pytorch_losses
 from argus.optimizer import pytorch_optimizers
 
@@ -200,6 +200,7 @@ class BuildModel(metaclass=ModelMeta):
 
     def set_device(self, device):
         device = cast_device(device)
+        str_device = device_to_str(device)
         nn_module = self.get_nn_module()
 
         if isinstance(device, (list, tuple)):
@@ -211,11 +212,9 @@ class BuildModel(metaclass=ModelMeta):
                     raise ValueError
                 device_ids.append(dev.index)
             nn_module = DataParallel(nn_module, device_ids=device_ids)
-            self.params['device'] = [str(d) for d in device]
             device = device[0]
-        else:
-            self.params['device'] = str(self.device)
 
+        self.params['device'] = str_device
         self.device = device
         self.nn_module = nn_module.to(self.device)
         if self.loss is not default:

--- a/argus/model/model.py
+++ b/argus/model/model.py
@@ -3,9 +3,9 @@ import numbers
 
 import torch
 
-from argus.model.build import BuildModel, MODEL_REGISTRY
+from argus.model.build import BuildModel, MODEL_REGISTRY, cast_device
 from argus.engine import Engine, Events
-from argus.utils import deep_to, deep_detach, setup_logging
+from argus.utils import deep_to, deep_detach, setup_logging, device_to_str
 from argus.callbacks import Callback, on_epoch_complete
 from argus.callbacks.logging import metrics_logging
 from argus.metrics.metric import Metric, METRIC_REGISTRY
@@ -175,7 +175,8 @@ def load_model(file_path, device=None):
         if state['model_name'] in MODEL_REGISTRY:
             params = state['params']
             if device is not None:
-                device = torch.device(device).type
+                device = cast_device(device)
+                device = device_to_str(device)
                 params['device'] = device
 
             model_class = MODEL_REGISTRY[state['model_name']]

--- a/argus/model/model.py
+++ b/argus/model/model.py
@@ -2,7 +2,6 @@ import os
 import numbers
 
 import torch
-from torch.nn.parallel.data_parallel import DataParallel
 
 from argus.model.build import BuildModel, MODEL_REGISTRY
 from argus.engine import Engine, Events
@@ -140,11 +139,7 @@ class Model(BuildModel):
         return lrs
 
     def save(self, file_path):
-        if isinstance(self.nn_module, DataParallel):
-            nn_module = self.nn_module.module
-        else:
-            nn_module = self.nn_module
-
+        nn_module = self.get_nn_module()
         state = {
             'model_name': self.__class__.__name__,
             'params': self.params,
@@ -187,11 +182,7 @@ def load_model(file_path, device=None):
             model = model_class(params)
             nn_state_dict = deep_to(state['nn_state_dict'], model.device)
 
-            if isinstance(model.nn_module, DataParallel):
-                model.nn_module.module.load_state_dict(nn_state_dict)
-            else:
-                model.nn_module.load_state_dict(nn_state_dict)
-
+            model.get_nn_module().load_state_dict(nn_state_dict)
             model.nn_module.eval()
             return model
         else:

--- a/argus/utils.py
+++ b/argus/utils.py
@@ -2,6 +2,8 @@ import torch
 import collections
 import logging
 
+import warnings
+
 
 default = object()
 
@@ -18,6 +20,8 @@ def setup_logging(file_path=None):
 
 
 def to_device(input, device):
+    warnings.warn("'to_device' has been deprecated in favor of 'deep_to'",
+                  category=DeprecationWarning)
     if torch.is_tensor(input):
         return input.to(device=device)
     elif isinstance(input, str):
@@ -31,6 +35,8 @@ def to_device(input, device):
 
 
 def detach_tensors(input):
+    warnings.warn("'detach_tensors' has been deprecated in favor of 'deep_detach'",
+                  category=DeprecationWarning)
     if torch.is_tensor(input):
         return input.detach()
     elif isinstance(input, str):
@@ -41,6 +47,34 @@ def detach_tensors(input):
         return [detach_tensors(sample) for sample in input]
     else:
         raise TypeError(f"Input must contain tensor, dict or list, found {type(input)}")
+
+
+def deep_to(input, *args, **kwarg):
+    if torch.is_tensor(input):
+        return input.to(*args, **kwarg)
+    elif isinstance(input, str):
+        return input
+    elif isinstance(input, collections.Sequence):
+        return [deep_to(sample, *args, **kwarg) for sample in input]
+    elif isinstance(input, collections.Mapping):
+        return {k: deep_to(sample, *args, **kwarg) for k, sample in input.items()}
+    elif isinstance(input, torch.nn.Module):
+        return input.to(*args, **kwarg)
+    else:
+        return input
+
+
+def deep_detach(input):
+    if torch.is_tensor(input):
+        return input.detach()
+    elif isinstance(input, str):
+        return input
+    elif isinstance(input, collections.Sequence):
+        return [deep_detach(sample) for sample in input]
+    elif isinstance(input, collections.Mapping):
+        return {k: deep_detach(sample) for k, sample in input.items()}
+    else:
+        return input
 
 
 def inheritors(cls):

--- a/argus/utils.py
+++ b/argus/utils.py
@@ -77,6 +77,13 @@ def deep_detach(input):
         return input
 
 
+def device_to_str(device):
+    if isinstance(device, (list, tuple)):
+        return [str(d) for d in device]
+    else:
+        return str(device)
+
+
 def inheritors(cls):
     subclasses = set()
     cls_list = [cls]

--- a/examples/mnist_vae.py
+++ b/examples/mnist_vae.py
@@ -62,6 +62,7 @@ class VAE(nn.Module):
         self.fc22 = nn.Linear(400, 20)
         self.fc3 = nn.Linear(20, 400)
         self.fc4 = nn.Linear(400, 784)
+        self.sigmoid = nn.Sigmoid()
 
     def encode(self, x):
         h1 = F.relu(self.fc1(x))
@@ -77,7 +78,7 @@ class VAE(nn.Module):
 
     def decode(self, z):
         h3 = F.relu(self.fc3(z))
-        return F.sigmoid(self.fc4(h3))
+        return self.sigmoid(self.fc4(h3))
 
     def forward(self, x):
         mu, logvar = self.encode(x.view(-1, 784))
@@ -89,7 +90,7 @@ class VAE(nn.Module):
 class VaeLoss(nn.modules.Module):
     def forward(self, inp, trg):
         recon, mu, logvar = inp
-        bce = F.binary_cross_entropy(recon, trg.view(-1, 784), size_average=False)
+        bce = F.binary_cross_entropy(recon, trg.view(-1, 784), reduction='sum')
 
         # see Appendix B from VAE paper:
         # Kingma and Welling. Auto-Encoding Variational Bayes. ICLR, 2014


### PR DESCRIPTION
Data parallel for multi-gpu training. 

Select gpu with device indexing:
```
model = load_model(model_path, device="cuda:1")
model.set_device("cuda:0")
```

For multi-gpu you can use list of devices: 
```
params = {
    ...,
    'device': ['cuda:0', 'cuda:1']
}
model = CnnFinetune(params)

model = load_model(model_path, device=["cuda:1", "cuda:0"])
model.set_device(["cuda:0", "cuda:1"])
```
Batch tensors will be scattered on dim 0. First device in list is location of output. 

By default device "cuda" is one gpu training on [torch.cuda.current_device](https://pytorch.org/docs/stable/cuda.html#torch.cuda.current_device).

