### PR TITLE
Model.train: add `mode` arg (now like in torch)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update &&\
     sysstat libtcmalloc-minimal4 pkgconf autoconf libtool \
     python3 python3-pip python3-dev python3-setuptools \
     libsm6 libxext6 libxrender-dev &&\
-    ln -s /usr/bin/python3 /usr/bin/python &&\
-    ln -s /usr/bin/pip3 /usr/bin/pip &&\
+    ln -sf /usr/bin/python3 /usr/bin/python &&\
+    ln -sf /usr/bin/pip3 /usr/bin/pip &&\
     apt-get clean &&\
     apt-get autoremove &&\
     rm -rf /var/lib/apt/lists/* &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,13 @@ RUN apt-get update &&\
     rm -rf /var/lib/apt/lists/* &&\
     rm -rf /var/cache/apt/archives/*
 
-RUN pip3 install --no-cache-dir numpy==1.20.1
+RUN pip3 install --no-cache-dir numpy==1.20.3
 
 # Install PyTorch
 RUN pip3 install --no-cache-dir \
-    torch==1.8.0+cu111 \
-    torchvision==0.9.0+cu111 \
-    torchaudio==0.8.0 \
+    torch==1.8.1+cu111 \
+    torchvision==0.9.1+cu111 \
+    torchaudio==0.8.1 \
     -f https://download.pytorch.org/whl/torch_stable.html
 
 # Docs requirements

--- a/argus/model/model.py
+++ b/argus/model/model.py
@@ -369,12 +369,11 @@ class Model(BuildModel):
         """Set the nn_module into train mode.
 
         Args:
-            mode (bool): whether to set training mode (``True``) or evaluation
-                         mode (``False``). Default: ``True``.
+            mode (bool): Set train mode, otherwise eval mode. Defaults to True.
         """
-        self.nn_module.train(mode)
+        if self.nn_module.training != mode:
+            self.nn_module.train(mode)
 
     def eval(self):
         """Set the nn_module into eval mode."""
-        if self.nn_module.training:
-            self.nn_module.eval()
+        self.train(mode=False)

--- a/argus/model/model.py
+++ b/argus/model/model.py
@@ -365,10 +365,9 @@ class Model(BuildModel):
             prediction = self.prediction_transform(prediction)
             return prediction
 
-    def train(self):
+    def train(self, mode: bool = True):
         """Set the nn_module into train mode."""
-        if not self.nn_module.training:
-            self.nn_module.train()
+        self.nn_module.train(mode)
 
     def eval(self):
         """Set the nn_module into eval mode."""

--- a/argus/model/model.py
+++ b/argus/model/model.py
@@ -366,7 +366,12 @@ class Model(BuildModel):
             return prediction
 
     def train(self, mode: bool = True):
-        """Set the nn_module into train mode."""
+        """Set the nn_module into train mode.
+
+        Args:
+            mode (bool): whether to set training mode (``True``) or evaluation
+                         mode (``False``). Default: ``True``.
+        """
         self.nn_module.train(mode)
 
     def eval(self):

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==3.5.2
-pydata-sphinx-theme==0.5.0
+sphinx==4.0.1
+pydata-sphinx-theme==0.6.3

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -52,6 +52,24 @@ class TestModelMethod:
         assert not model.nn_module.training
         model.train()
         assert model.nn_module.training
+        model.train(False)
+        assert not model.nn_module.training
+        model.train(True)
+        assert model.nn_module.training
+        
+        # Check that no "toogle" behavior after enabling already enabled mode
+        model.train(True)
+        assert model.nn_module.training
+        model.train()
+        assert model.nn_module.training
+        model.eval()
+        assert not model.nn_module.training
+        model.eval()
+        assert not model.nn_module.training
+        model.train(False)
+        assert not model.nn_module.training
+        
+        
 
     def test_fit_train_loader(self,
                               get_batch_function,

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -68,8 +68,6 @@ class TestModelMethod:
         assert not model.nn_module.training
         model.train(False)
         assert not model.nn_module.training
-        
-        
 
     def test_fit_train_loader(self,
                               get_batch_function,

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -56,7 +56,7 @@ class TestModelMethod:
         assert not model.nn_module.training
         model.train(True)
         assert model.nn_module.training
-        
+
         # Check that no "toogle" behavior after enabling already enabled mode
         model.train(True)
         assert model.nn_module.training

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-pytest==6.2.2
-pytest-cov==2.11.1
+pytest==6.2.4
+pytest-cov==2.12.0
 mypy==0.812
-flake8==3.9.0
+flake8==3.9.2


### PR DESCRIPTION
The implementation in `torch`: https://pytorch.org/docs/1.8.1/_modules/torch/nn/modules/module.html#Module.train
`mode` exists at least since torch 1.1.0

I suppose it is introduced for scenarios like the following one:
```
def ...(..., use_model_for_training, ...):
    ...
    module.train(use_model_for_training)
    ...
```

... and get rid of the following construction:
```
if use_model_for_training:
    module.train()
else:
    module.eval()
```